### PR TITLE
feat: `SearchBar`를 구현한다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.21.1",
-    "styled-components": "^6.1.3"
+    "styled-components": "^6.1.3",
+    "vite-plugin-svgr": "^4.2.0"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.6.6",

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchIcon } from './search.svg?react';

--- a/src/assets/search.svg
+++ b/src/assets/search.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.70833 15.0417C12.2061 15.0417 15.0417 12.2061 15.0417 8.70833C15.0417 5.21053 12.2061 2.375 8.70833 2.375C5.21053 2.375 2.375 5.21053 2.375 8.70833C2.375 12.2061 5.21053 15.0417 8.70833 15.0417Z" stroke="#A8A8A8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M16.6254 16.6253L13.1816 13.1815" stroke="#A8A8A8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,66 @@
+import { InputHTMLAttributes, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { SearchIcon } from '@assets/index';
+
+interface SearchBarProps extends InputHTMLAttributes<HTMLInputElement> {
+  isFocused?: boolean;
+}
+
+const SearchBarWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const StyledSearchBar = styled.input`
+  width: 100%;
+  height: 47px;
+  margin: 0 18px;
+  padding: 0 14px;
+  border: none;
+  border-radius: 9px;
+  background: #f5f5f5;
+  outline: none;
+
+  font-family: Pretendard;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  letter-spacing: -0.6px;
+
+  &::placeholder {
+    color: #b4b4b4;
+  }
+`;
+
+const IconWrapper = styled.div`
+  position: absolute;
+  top: 14px;
+  left: 32px;
+`;
+
+const SearchBar = ({ isFocused }: SearchBarProps) => {
+  const [isExpanded, setIsExpanded] = useState(isFocused);
+  const [placeholder, setPlaceholder] = useState('');
+
+  useEffect(() => {
+    isExpanded ? setPlaceholder('목적지 검색') : setPlaceholder('');
+  }, [isExpanded]);
+
+  const expandSearchBar = () => {
+    setIsExpanded(true);
+  };
+
+  return (
+    <SearchBarWrapper>
+      {!isExpanded && (
+        <IconWrapper>
+          <SearchIcon />
+        </IconWrapper>
+      )}
+      <StyledSearchBar placeholder={placeholder} onFocus={expandSearchBar} />
+    </SearchBarWrapper>
+  );
+};
+
+export default SearchBar;

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite-plugin-svgr/client" />
+declare module '*.svg?react' {
+  import React = require('react');
+  export const ReactComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
+  const src: string;
+  export default src;
+}

--- a/src/stories/SearchBar.stories.tsx
+++ b/src/stories/SearchBar.stories.tsx
@@ -1,0 +1,22 @@
+import SearchBar from '@components/SearchBar';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/SearchBar',
+  component: SearchBar,
+  parameters: {
+    layout: 'centered',
+  },
+
+  tags: ['autodocs'],
+} satisfies Meta<typeof SearchBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Focused: Story = {
+  args: {
+    isFocused: true,
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,14 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2020",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
     "outDir": "./dist",
-
     /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
@@ -15,22 +18,33 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
-
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-
     /* Path */
     "baseUrl": ".",
     "paths": {
-      "@pages/*": ["src/pages/*"],
-      "@components/*": ["src/components/*"],
-      "@assets/*": ["src/assets/*"],
-      "@hooks/*": ["src/hooks/*"],
-      "@utils/*": ["src/utils/*"]
+      "@pages/*": [
+        "src/pages/*"
+      ],
+      "@components/*": [
+        "src/components/*"
+      ],
+      "@assets/*": [
+        "src/assets/*"
+      ],
+      "@hooks/*": [
+        "src/hooks/*"
+      ],
+      "@utils/*": [
+        "src/utils/*"
+      ]
     }
   },
-  "include": ["src"]
+  "include": [
+    "src",
+    "custom.d.ts"
+  ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import svgr from 'vite-plugin-svgr';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), svgr()],
   resolve: {
     alias: [
       { find: '@pages', replacement: '/src/pages' },


### PR DESCRIPTION
## 구현한 기능

- `SearchBar`를 구현했습니다.
- `BottomSheet`과 연결된 컴포넌트라서 `BottomSheet`이 머지된 이후에도 손봐야할 것 같습니다. 현재는 피그마에 따른 스타일만 적용한 상태입니다.

<img width="310" alt="스크린샷 2024-01-22 오후 2 38 54" src="https://github.com/parkingkim/parkingkim-webapp/assets/90092440/a1cc680c-934c-456f-ae88-bde295c29102">
<img width="323" alt="스크린샷 2024-01-22 오후 2 39 10" src="https://github.com/parkingkim/parkingkim-webapp/assets/90092440/ec8246ab-f5b4-48f1-8dbf-3371beb89d6f">

closes #10 
